### PR TITLE
fix(logger): Get correct name and version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,11 @@ Exception made of:
 * ? Add parent logger ?
 * Add support for streams
 # ? Include Joda-time formats ?
+
+
+# Warning
+Currently only works if the logger is created in the main thread.
+(It can still be used from any thread.)
+Since the main class implements a logger this should always be true,
+just in case a warning has been added to the README.md.
+To implement a version callable by any thread look into [this](http://stackoverflow.com/questions/8275403/portable-way-to-find-name-of-main-class-from-java-code).

--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -86,6 +86,16 @@ class Logger(module: String) {
 }
 
 object Logger {
+
+  def getNameAndVersion: (String, String) = {
+    val stack = Thread.currentThread.getStackTrace
+    val mainStackElement = stack(stack.length - 1)
+    val mainClass = Class.forName(mainStackElement.getClassName())
+    (mainClass.getSimpleName, mainClass.getPackage.getImplementationVersion)
+  }
+
+  val (name, version) = getNameAndVersion
+
   private val tz = TimeZone.getTimeZone("UTC")
   private val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss:SSS'Z'")
   df.setTimeZone(tz)
@@ -100,8 +110,8 @@ object Logger {
   }
 
   private val coreFields: List[JField] = List(
-    JField("name", JString(getClass.getPackage.getName)),
-    JField("version", JString(getClass.getPackage.getImplementationVersion)),
+    JField("name", JString(name)),
+    JField("version", JString(version)),
     JField("hostname", JString(java.net.InetAddress.getLocalHost.getHostName()))
   )
 


### PR DESCRIPTION
This method only works if the logger is created in the main thread.
(It can still be used from any thread.)
Since the main class implements a logger this should always be true,
just in case a warning has been added to the README.md.
